### PR TITLE
Treat `is_anonymous` as an attribute, not a callable

### DIFF
--- a/drflog/mixins.py
+++ b/drflog/mixins.py
@@ -30,7 +30,7 @@ class LogMixin(object):
     def initial(self, request, *args, **kwargs):
 
         self.request.drflog = Entry.objects.create(
-            user=request.user if not request.user.is_anonymous() else None,
+            user=request.user if not request.user.is_anonymous else None,
             ip=self.parse_client_ip(request),
             host=request.get_host(),
             path=request.path,


### PR DESCRIPTION
According to the docs, `is_anonymous` is not supposed to be a callable.
Source: https://docs.djangoproject.com/en/2.0/ref/contrib/auth/#django.contrib.auth.models.User.is_anonymous